### PR TITLE
Parent Offset Clipping Image Issue

### DIFF
--- a/js/smoothproducts.js
+++ b/js/smoothproducts.js
@@ -242,11 +242,11 @@
 			$('.sp-large').mousemove(function(e) {
 				var viewWidth = $(this).width(),
 					viewHeight = $(this).height(),
+					viewOffset = $(this).offset(),
 					largeWidth = $(this).find('.sp-zoom').width(),
 					largeHeight = $(this).find('.sp-zoom').height(),
-					parentOffset = $(this).parent().offset(),
-					relativeXPosition = (e.pageX - parentOffset.left),
-					relativeYPosition = (e.pageY - parentOffset.top),
+					relativeXPosition = (e.pageX - viewOffset.left),
+					relativeYPosition = (e.pageY - viewOffset.top),
 					moveX = Math.floor((relativeXPosition * (viewWidth - largeWidth) / viewWidth)),
 					moveY = Math.floor((relativeYPosition * (viewHeight - largeHeight) / viewHeight));
 


### PR DESCRIPTION
When hovering the image to produce the zoom effect, the offset of the parent caused by the border on your demo has an additional 5 pixels being cut off of the left part of the image. By removing ".parent()" you can change the location of the images as well as modify borders or margins within the parent container without altering the positioning of the zoom. I modified the variable names to be consistent with the project format.